### PR TITLE
Option to prevent refresh on select/unselect/clearselect

### DIFF
--- a/source/jsCalendar.js
+++ b/source/jsCalendar.js
@@ -68,6 +68,8 @@ var jsCalendar = (function(){
         this._create();
         // Update
         this._update();
+        // set not frozen
+        this._isFrozen = false;
     };
 
     // Languages
@@ -937,9 +939,23 @@ var jsCalendar = (function(){
         return this;
     };
 
+    JsCalendar.prototype.freeze = function() {
+        this._isFrozen = true;
+    };
+
+    JsCalendar.prototype.unfreeze = function() {
+        this._isFrozen = false;
+    };
+
+    JsCalendar.prototype.isFrozen = function() {
+        return this._isFrozen;
+    };
+
     // Refresh
     // Safe _update
     JsCalendar.prototype.refresh = function(date) {
+        if (true === this._isFrozen) return this;
+
         // If date provided
         if (typeof date !== 'undefined') {
             // If date is in range
@@ -1020,7 +1036,7 @@ var jsCalendar = (function(){
     };
 
     // Select dates
-    JsCalendar.prototype.select = function(dates, shouldRefresh = true){
+    JsCalendar.prototype.select = function(dates){
         // If no arguments
         if (typeof dates === 'undefined') {
             // Return
@@ -1035,16 +1051,14 @@ var jsCalendar = (function(){
         // Select dates
         this._selectDates(dates);
         // Refresh
-        if (true === shouldRefresh) {
-            this.refresh();
-        }
+        this.refresh();
 
         // Return
         return this;
     };
 
     // Unselect dates
-    JsCalendar.prototype.unselect = function(dates, shouldRefresh = true){
+    JsCalendar.prototype.unselect = function(dates){
         // If no arguments
         if (typeof dates === 'undefined') {
             // Return
@@ -1059,22 +1073,18 @@ var jsCalendar = (function(){
         // Unselect dates
         this._unselectDates(dates);
         // Refresh
-        if (true === shouldRefresh) {
-            this.refresh();
-        }
+        this.refresh();
 
         // Return
         return this;
     };
 
     // Unselect all dates
-    JsCalendar.prototype.clearselect = function(shouldRefresh = true){
+    JsCalendar.prototype.clearselect = function(){
         // Unselect all dates
         this._unselectAllDates();
         // Refresh
-        if (true === shouldRefresh) {
-            this.refresh();
-        }
+        this.refresh();
 
         // Return
         return this;

--- a/source/jsCalendar.js
+++ b/source/jsCalendar.js
@@ -941,10 +941,12 @@ var jsCalendar = (function(){
 
     JsCalendar.prototype.freeze = function() {
         this._isFrozen = true;
+        return this;
     };
 
     JsCalendar.prototype.unfreeze = function() {
         this._isFrozen = false;
+        return this;
     };
 
     JsCalendar.prototype.isFrozen = function() {

--- a/source/jsCalendar.js
+++ b/source/jsCalendar.js
@@ -716,6 +716,7 @@ var jsCalendar = (function(){
 
     // Update calendar
     JsCalendar.prototype._update = function() {
+        if (true === this._isFrozen) return this;
         // Get month info
         var month = this._getVisibleMonth(this._date);
         // Save data
@@ -956,8 +957,6 @@ var jsCalendar = (function(){
     // Refresh
     // Safe _update
     JsCalendar.prototype.refresh = function(date) {
-        if (true === this._isFrozen) return this;
-
         // If date provided
         if (typeof date !== 'undefined') {
             // If date is in range

--- a/source/jsCalendar.js
+++ b/source/jsCalendar.js
@@ -1020,7 +1020,7 @@ var jsCalendar = (function(){
     };
 
     // Select dates
-    JsCalendar.prototype.select = function(dates){
+    JsCalendar.prototype.select = function(dates, shouldRefresh = true){
         // If no arguments
         if (typeof dates === 'undefined') {
             // Return
@@ -1035,14 +1035,16 @@ var jsCalendar = (function(){
         // Select dates
         this._selectDates(dates);
         // Refresh
-        this.refresh();
+        if (true === shouldRefresh) {
+            this.refresh();
+        }
 
         // Return
         return this;
     };
 
     // Unselect dates
-    JsCalendar.prototype.unselect = function(dates){
+    JsCalendar.prototype.unselect = function(dates, shouldRefresh = true){
         // If no arguments
         if (typeof dates === 'undefined') {
             // Return
@@ -1057,18 +1059,22 @@ var jsCalendar = (function(){
         // Unselect dates
         this._unselectDates(dates);
         // Refresh
-        this.refresh();
+        if (true === shouldRefresh) {
+            this.refresh();
+        }
 
         // Return
         return this;
     };
 
     // Unselect all dates
-    JsCalendar.prototype.clearselect = function(){
+    JsCalendar.prototype.clearselect = function(shouldRefresh = true){
         // Unselect all dates
         this._unselectAllDates();
         // Refresh
-        this.refresh();
+        if (true === shouldRefresh) {
+            this.refresh();
+        }
 
         // Return
         return this;


### PR DESCRIPTION
New option to prevent repaint when selecting. comes in handy for preventing recursion re calling select within on*Render callbacks.

There's no update to jsCalendar.min.js ... what's the build process?

Example
```ts
    myCalendar.onMonthRender(<T extends {start: Date, end:Date}>(_index: number, _element: HTMLElement, info: T) => {
        // @ts-ignore
        const min = jsCalendar.tools.dateToString(info.start, "YYYY-MM-DD") as string
        // @ts-ignore
        const max = jsCalendar.tools.dateToString(info.end, "YYYY-MM-DD") as string

        if (true !== myCalendar._isSelectionComplete) {
            fetch(`/beef/${min}/${max}`, {
                method: "GET",
                headers: {
                    'Content-Type': 'application/json'
                },
            })
                .then(response => response.json())
                .then((json) => {
                    if (Array.isArray(json.output)) {
                        json.output.forEach(<T extends {date:string,points:number}>(item: T) => {
                            const date = item.date
                            const points = item.points
                            // selecting causes paint, so don't do it as it induces recursion
                            myCalendar.select(new Date(date), false)
                        })
                    }
                })
                .finally(() => {
                    myCalendar._isSelectionComplete = true
                    myCalendar.refresh()
                    myCalendar._isSelectionComplete = false
                })
        }
    })
```
Without the second argument on `myCalendar.select(new Date(date), false)`, a recursive condition is created.
